### PR TITLE
s3: Single-chunk PutObject

### DIFF
--- a/src/test/scala/org/aws4s/s3/S3SmokeTest.scala
+++ b/src/test/scala/org/aws4s/s3/S3SmokeTest.scala
@@ -11,7 +11,7 @@ class S3SmokeTest extends SmokeTest {
   "Essential object functionality" should "be alright" in {
 
     val s3      = S3(httpClient, region, credentials)
-    val data    = "dump"
+    val data    = List.fill(256*11)("data").combineAll  // 11 KB of data
     val bucket  = BucketName("aws4s-smoketest") // TODO: create this bucket
     val objPath = ObjectPath("/dump/data")
     val obj     = IO(Stream.eval(IO(data.getBytes.iterator)) >>= (Stream.fromIterator[IO, Byte](_)))


### PR DESCRIPTION
Makes sure that the `PutObject` payload is a single chunk, since that's the only way it's supported.

Closes #27 
Should be enhanced in #29